### PR TITLE
Implement function to extract_star_metadata before assigning stars to halo

### DIFF
--- a/stars_assignment_to_halos.py
+++ b/stars_assignment_to_halos.py
@@ -114,8 +114,10 @@ def extract_star_metadata(pfs, idx, numsegs,savedir):
     for c, vals in sorted(my_storage.items()):
         for info in infos:
             output[info] = np.append(output[info], vals[info])
-    print('Snapshot Idx %s is finished' % idx)
-    np.save(savedir + '/star_metadata_allbox_'+str(idx)+'.npy', output)
+    if yt.is_root():
+        print('Star metadata in Snapshot Idx %s is extracted' % idx)
+        np.save(savedir + '/star_metadata_allbox_'+str(idx)+'.npy', output)
+    return output
 
 def stars_assignment(rawtree, pfs, metadata_dir, print_mode = True):
     """

--- a/stars_assignment_to_halos.py
+++ b/stars_assignment_to_halos.py
@@ -127,11 +127,17 @@ def extract_star_metadata(pfs, idx, numsegs, halo_dir, metadata_dir):
     output = {}
     infos = ['type', 'mass', 'pos', 'vel', 'age', 'met', 'ID']
     for info in infos:
-        output[info] = np.array([])
+        if info == 'pos':
+            output[info] = np.empty(shape=(0,3))
+        else:
+            output[info] = np.array([])
     #Go through different cores/regions to load the stars info to the output
     for c, vals in sorted(my_storage.items()):
         for info in infos:
-            output[info] = np.append(output[info], vals[info])
+            if info == 'pos':
+                output[info] = np.vstack((output[info], vals[info]))
+            else:
+                output[info] = np.append(output[info], vals[info])
     #Because there is a buffer region, we use np.unique to remove the duplicated stars
     if yt.is_root():
         print('Before removing duplicates, the number of stars is:', len(output['ID']))


### PR DESCRIPTION
Implement a function to extract_star_metadata before assigning stars to halo. This extraction step is also parallelized to make it faster (about ~60 seconds per snapshot). Thus, we didn't need to run the separate extract_star_metadata step before this code.